### PR TITLE
Add our partner_id to azurerm provider

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -5,6 +5,7 @@ terraform {
 provider "azurerm" {
   version = ">=2.7.0"
   features {}
+  partner_id = "31912fbf-f6dd-5176-bffb-0a01e8ac71f2"
 }
 
 provider "random" {


### PR DESCRIPTION
We want to be able to track deployments using this terraform module, so add our partner id for tracking purposes.

I noted the potential for our partner id to get used outside of our control due to this being a public repo (ie if somebody were to google example terraform and copy/paste liberally, or some other unlikely scenario) and considered making it a variable input.

We could even use terraforms md5sum features to ensure the partner id input matches ours, ensuring it does get used, however, nobody seems especially concerned with it so unless somebody reviewing thinks it's worth it, I'm not going to go that far.