### PR TITLE
PLAT-9784 - Upgrade azurerm provider to 4.67

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.0"
+      version = "~> 4.67"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Synchronizes provider versions `with terraform-azure-aks`
- azurerm provider 3.x is EOL; 4.67 enables support for AKS 1.35 features (Ubuntu 24.04, API server VNet integration, node provisioning profiles)